### PR TITLE
Исправил проблему, когда невидимые элементы загораживали видимые

### DIFF
--- a/SwipeCards.js
+++ b/SwipeCards.js
@@ -684,10 +684,10 @@ export default class SwipeCards extends Component {
   render () {
     return (
       <View style={[styles.container, this.props.containerStyle]}>
-        {this.props.stack ? this.renderStack() : this.renderCard()}
         {this.renderNope()}
         {this.renderMaybe()}
         {this.renderYup()}
+        {this.props.stack ? this.renderStack() : this.renderCard()}
         <View style={this.props.buttonContainerStyle}>
           {this.renderNopeButton()}
           {this.renderMaybeButton()}


### PR DESCRIPTION
https://github.com/pridemon/babynames-reactnative/issues/110
Эта проблема возникала из-за того, что текст юп-мессейджа загораживал шарилку. Перенес рендеринг карты ниже, теперь она считается более приоритетным элементом, и находится на переднем плане (танцы с z-index-ами не помогли), а всякие юпы не загораживают ее внутренние элементы.